### PR TITLE
Corrige remanente de Python2

### DIFF
--- a/Examples/AgentExamples/SimpleDirectoryService.py
+++ b/Examples/AgentExamples/SimpleDirectoryService.py
@@ -92,7 +92,7 @@ def register():
         agn_type = gm.value(subject=content, predicate=DSO.AgentType)
         rsearch = dsgraph.triples((None, DSO.AgentType, agn_type))
         if rsearch is not None:
-            agn_uri = rsearch.next()[0]
+            agn_uri = next(rsearch)[0]
             agn_add = dsgraph.value(subject=agn_uri, predicate=DSO.Address)
             gr = Graph()
             gr.bind('dso', DSO)


### PR DESCRIPTION
La operación `generator.next()` que era válida en Python2 fue reemplazada por `generator.__next__()` en Python 3.0. La nueva manera recomendada de hacer esto es con `next(generator)`.
Este error provocaba una excepción durante el registro de SimplePersonalAgent.
Referencia: https://stackoverflow.com/questions/1073396/is-generator-next-visible-in-python-3-0